### PR TITLE
fix: convert datetime to ISO format strings for JSON serialization in copy rates/ticks functions

### DIFF
--- a/examples/pydantic_ai_test.py
+++ b/examples/pydantic_ai_test.py
@@ -1,0 +1,130 @@
+"""
+Example demonstrating the JSON serialization fix for Pydantic AI integration.
+
+This example shows that the copy_rates_from_pos function now returns
+JSON-serializable data that works with Pydantic AI and MCP protocol.
+"""
+
+import asyncio
+import json
+from datetime import datetime
+
+# This example demonstrates the fix without requiring actual MT5 connection
+
+
+def demonstrate_json_serialization():
+    """Show that the returned data structure is JSON-serializable"""
+
+    # Simulated response from copy_rates_from_pos after the fix
+    mock_response = [
+        {
+            "time": "2024-01-22T10:00:00",  # Now a string, not Timestamp!
+            "open": 1.0850,
+            "high": 1.0865,
+            "low": 1.0845,
+            "close": 1.0860,
+            "tick_volume": 1250,
+            "spread": 2,
+            "real_volume": 125000,
+        },
+        {
+            "time": "2024-01-22T11:00:00",
+            "open": 1.0860,
+            "high": 1.0875,
+            "low": 1.0855,
+            "close": 1.0870,
+            "tick_volume": 1100,
+            "spread": 2,
+            "real_volume": 110000,
+        },
+    ]
+
+    # This will now work - before the fix, this would fail!
+    try:
+        json_str = json.dumps(mock_response, indent=2)
+        print("✅ JSON Serialization Successful!")
+        print("\nJSON Output:")
+        print(json_str)
+        return True
+    except (TypeError, ValueError) as e:
+        print(f"❌ JSON Serialization Failed: {e}")
+        return False
+
+
+def demonstrate_datetime_parsing():
+    """Show how to parse the ISO format datetime strings if needed"""
+
+    time_str = "2024-01-22T10:00:00"
+
+    # Parse back to datetime if needed
+    dt = datetime.fromisoformat(time_str)
+    print(f"\n✅ DateTime parsing successful!")
+    print(f"Original string: {time_str}")
+    print(f"Parsed datetime: {dt}")
+    print(f"Type: {type(dt)}")
+
+
+async def demonstrate_pydantic_ai_usage():
+    """
+    Pseudo-code example showing how this works with Pydantic AI.
+    
+    Note: This is a conceptual example. For actual implementation,
+    see the pydantic_ai_integration.md documentation.
+    """
+    print("\n" + "=" * 60)
+    print("Pydantic AI Integration Example (Conceptual)")
+    print("=" * 60)
+
+    # When using with Pydantic AI through MCP:
+    # 1. Agent calls the tool through MCP protocol
+    # 2. Tool returns JSON-serializable data (now works!)
+    # 3. MCP serializes the response to JSON
+    # 4. Agent receives and processes the data
+
+    example_tool_call = {
+        "tool": "copy_rates_from_pos",
+        "arguments": {"symbol": "EURUSD", "timeframe": 60, "start_pos": 0, "count": 100},
+    }
+
+    example_response = {
+        "success": True,
+        "data": [
+            {
+                "time": "2024-01-22T10:00:00",
+                "open": 1.0850,
+                "high": 1.0865,
+                "low": 1.0845,
+                "close": 1.0860,
+                "tick_volume": 1250,
+                "spread": 2,
+                "real_volume": 125000,
+            }
+        ],
+    }
+
+    print(f"\nTool Call: {json.dumps(example_tool_call, indent=2)}")
+    print(f"\nTool Response (JSON-serializable): {json.dumps(example_response, indent=2)}")
+    print("\n✅ This now works with Pydantic AI!")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("MT5 MCP Server - JSON Serialization Fix Demonstration")
+    print("=" * 60)
+
+    # Test 1: JSON serialization
+    print("\n1. Testing JSON Serialization")
+    print("-" * 60)
+    demonstrate_json_serialization()
+
+    # Test 2: DateTime parsing
+    print("\n2. Testing DateTime Parsing")
+    print("-" * 60)
+    demonstrate_datetime_parsing()
+
+    # Test 3: Pydantic AI conceptual example
+    asyncio.run(demonstrate_pydantic_ai_usage())
+
+    print("\n" + "=" * 60)
+    print("All demonstrations completed successfully! ✅")
+    print("=" * 60)

--- a/src/mcp_mt5/main.py
+++ b/src/mcp_mt5/main.py
@@ -506,9 +506,9 @@ def copy_rates_from_pos(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(rates)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
 
     return df.to_dict("records")
 
@@ -539,9 +539,9 @@ def copy_rates_from_date(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(rates)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
 
     return df.to_dict("records")
 
@@ -572,9 +572,9 @@ def copy_rates_range(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(rates)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
 
     return df.to_dict("records")
 
@@ -606,11 +606,11 @@ def copy_ticks_from_pos(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(ticks)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
     if "time_msc" in df.columns:
-        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms")
+        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms").dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     return df.to_dict("records")
 
@@ -641,11 +641,11 @@ def copy_ticks_from_date(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(ticks)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
     if "time_msc" in df.columns:
-        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms")
+        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms").dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     return df.to_dict("records")
 
@@ -676,11 +676,11 @@ def copy_ticks_range(
 
     # Convert numpy array to list of dictionaries
     df = pd.DataFrame(ticks)
-    # Convert time to datetime
+    # Convert time to ISO format string for JSON serialization
     if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df["time"] = pd.to_datetime(df["time"], unit="s").dt.strftime("%Y-%m-%dT%H:%M:%S")
     if "time_msc" in df.columns:
-        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms")
+        df["time_msc"] = pd.to_datetime(df["time_msc"], unit="ms").dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     return df.to_dict("records")
 

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1,0 +1,213 @@
+"""Tests for market data tools to ensure JSON serialization compatibility"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import MetaTrader5 as mt5
+import numpy as np
+import pytest
+
+from mcp_mt5.main import (
+    copy_rates_from_date,
+    copy_rates_from_pos,
+    copy_rates_range,
+    copy_ticks_from_date,
+    copy_ticks_from_pos,
+    copy_ticks_range,
+)
+
+
+@pytest.fixture
+def mock_rates_data():
+    """Create mock rate data that simulates MT5 response"""
+    # MT5 returns a structured numpy array
+    dtype = [
+        ("time", "i8"),
+        ("open", "f8"),
+        ("high", "f8"),
+        ("low", "f8"),
+        ("close", "f8"),
+        ("tick_volume", "i8"),
+        ("spread", "i4"),
+        ("real_volume", "i8"),
+    ]
+
+    data = np.array(
+        [
+            (1634025600, 1.1615, 1.1625, 1.1610, 1.1620, 1250, 2, 125000),
+            (1634029200, 1.1620, 1.1630, 1.1615, 1.1625, 1100, 2, 110000),
+            (1634032800, 1.1625, 1.1635, 1.1620, 1.1630, 1350, 2, 135000),
+        ],
+        dtype=dtype,
+    )
+    return data
+
+
+@pytest.fixture
+def mock_ticks_data():
+    """Create mock tick data that simulates MT5 response"""
+    dtype = [
+        ("time", "i8"),
+        ("bid", "f8"),
+        ("ask", "f8"),
+        ("last", "f8"),
+        ("volume", "i8"),
+        ("time_msc", "i8"),
+        ("flags", "i4"),
+        ("volume_real", "f8"),
+    ]
+
+    data = np.array(
+        [
+            (1634025600, 1.1615, 1.1617, 1.1616, 100, 1634025600000, 134, 10.0),
+            (1634025601, 1.1616, 1.1618, 1.1617, 150, 1634025601000, 134, 15.0),
+        ],
+        dtype=dtype,
+    )
+    return data
+
+
+class TestCopyRatesFromPosJsonSerialization:
+    """Test that copy_rates_from_pos returns JSON-serializable data"""
+
+    @patch("mcp_mt5.main.mt5.copy_rates_from_pos")
+    def test_returns_json_serializable_data(self, mock_copy_rates, mock_rates_data):
+        """Test that the returned data can be serialized to JSON"""
+        mock_copy_rates.return_value = mock_rates_data
+
+        result = copy_rates_from_pos(symbol="EURUSD", timeframe=60, start_pos=0, count=3)
+
+        # This should not raise an exception if data is JSON-serializable
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")
+
+    @patch("mcp_mt5.main.mt5.copy_rates_from_pos")
+    def test_datetime_fields_are_strings(self, mock_copy_rates, mock_rates_data):
+        """Test that datetime fields are returned as ISO format strings"""
+        mock_copy_rates.return_value = mock_rates_data
+
+        result = copy_rates_from_pos(symbol="EURUSD", timeframe=60, start_pos=0, count=3)
+
+        assert len(result) > 0
+        # Check that time field is a string (ISO format)
+        assert isinstance(result[0]["time"], str)
+        # Verify it's a valid datetime string
+        datetime.fromisoformat(result[0]["time"])
+
+    @patch("mcp_mt5.main.mt5.copy_rates_from_pos")
+    def test_numeric_fields_preserved(self, mock_copy_rates, mock_rates_data):
+        """Test that numeric fields maintain their values"""
+        mock_copy_rates.return_value = mock_rates_data
+
+        result = copy_rates_from_pos(symbol="EURUSD", timeframe=60, start_pos=0, count=3)
+
+        assert len(result) == 3
+        # Check first bar
+        assert isinstance(result[0]["open"], (int, float))
+        assert isinstance(result[0]["high"], (int, float))
+        assert isinstance(result[0]["low"], (int, float))
+        assert isinstance(result[0]["close"], (int, float))
+        assert isinstance(result[0]["tick_volume"], (int, float))
+
+
+class TestCopyRatesFromDateJsonSerialization:
+    """Test that copy_rates_from_date returns JSON-serializable data"""
+
+    @patch("mcp_mt5.main.mt5.copy_rates_from_date")
+    def test_returns_json_serializable_data(self, mock_copy_rates, mock_rates_data):
+        """Test that the returned data can be serialized to JSON"""
+        mock_copy_rates.return_value = mock_rates_data
+
+        result = copy_rates_from_date(
+            symbol="EURUSD", timeframe=60, date_from=datetime(2024, 1, 1), count=3
+        )
+
+        # This should not raise an exception
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")
+
+
+class TestCopyRatesRangeJsonSerialization:
+    """Test that copy_rates_range returns JSON-serializable data"""
+
+    @patch("mcp_mt5.main.mt5.copy_rates_range")
+    def test_returns_json_serializable_data(self, mock_copy_rates, mock_rates_data):
+        """Test that the returned data can be serialized to JSON"""
+        mock_copy_rates.return_value = mock_rates_data
+
+        result = copy_rates_range(
+            symbol="EURUSD",
+            timeframe=60,
+            date_from=datetime(2024, 1, 1),
+            date_to=datetime(2024, 1, 2),
+        )
+
+        # This should not raise an exception
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")
+
+
+class TestCopyTicksJsonSerialization:
+    """Test that tick-related functions return JSON-serializable data"""
+
+    @patch("mcp_mt5.main.mt5.copy_ticks_from")
+    def test_copy_ticks_from_pos_json_serializable(self, mock_copy_ticks, mock_ticks_data):
+        """Test that copy_ticks_from_pos returns JSON-serializable data"""
+        mock_copy_ticks.return_value = mock_ticks_data
+
+        result = copy_ticks_from_pos(
+            symbol="EURUSD", start_time=datetime(2024, 1, 1), count=2
+        )
+
+        # This should not raise an exception
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")
+
+        # Check datetime fields are strings
+        assert isinstance(result[0]["time"], str)
+        assert isinstance(result[0]["time_msc"], str)
+
+    @patch("mcp_mt5.main.mt5.copy_ticks_from")
+    def test_copy_ticks_from_date_json_serializable(self, mock_copy_ticks, mock_ticks_data):
+        """Test that copy_ticks_from_date returns JSON-serializable data"""
+        mock_copy_ticks.return_value = mock_ticks_data
+
+        result = copy_ticks_from_date(
+            symbol="EURUSD", date_from=datetime(2024, 1, 1), count=2
+        )
+
+        # This should not raise an exception
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")
+
+    @patch("mcp_mt5.main.mt5.copy_ticks_range")
+    def test_copy_ticks_range_json_serializable(self, mock_copy_ticks, mock_ticks_data):
+        """Test that copy_ticks_range returns JSON-serializable data"""
+        mock_copy_ticks.return_value = mock_ticks_data
+
+        result = copy_ticks_range(
+            symbol="EURUSD", date_from=datetime(2024, 1, 1), date_to=datetime(2024, 1, 2)
+        )
+
+        # This should not raise an exception
+        try:
+            json_str = json.dumps(result)
+            assert isinstance(json_str, str)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"Result is not JSON-serializable: {e}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time-related fields now serialize as ISO-formatted strings for improved JSON compatibility across market data operations.

* **Documentation**
  * Added example demonstrating Pydantic AI integration workflow with JSON serialization handling.

* **Tests**
  * Added comprehensive JSON serialization compatibility tests for market data functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->